### PR TITLE
Change --manual, --api, etc. to string option and related fixes.

### DIFF
--- a/src/cli.ml
+++ b/src/cli.ml
@@ -17,20 +17,19 @@ Overrides $(b,--print)." in
   Cmdliner.Arg.(value & opt (some string) None & info ["o"; "output"]
                   ~docv:"FILE" ~doc)
 
-let cwd = Sys.getcwd ()
 let root_cmd =
   let doc = "Use the given root directory." in
-  Cmdliner.Arg.(value & opt string cwd & info ["root"]
+  Cmdliner.Arg.(value & opt string (Unix.getcwd ()) & info ["root"]
                   ~docv:"DIR" ~doc)
 
 let manual_cmd =
   let doc = "Use the given manual path." in
-  Cmdliner.Arg.(value & opt string cwd & info ["manual"]
+  Cmdliner.Arg.(value & opt (some string) None & info ["manual"]
                   ~docv:"DIR" ~doc)
 
 let api_cmd =
   let doc = "Use the given api path." in
-  Cmdliner.Arg.(value & opt string cwd & info ["api"]
+  Cmdliner.Arg.(value & opt (some string) None & info ["api"]
                   ~docv:"DIR" ~doc)
 
 let default_subproject_cmd =
@@ -41,12 +40,12 @@ Ocsiforge's old config.js for compatibility reasons. Do not use it otherwise!" i
 
 let img_cmd =
   let doc = "Use the given image directory path." in
-  Cmdliner.Arg.(value & opt string cwd & info ["images"]
+  Cmdliner.Arg.(value & opt (some string) None & info ["images"]
                   ~docv:"DIR" ~doc)
 
 let assets_cmd =
   let doc = "Use the given assets directory path." in
-  Cmdliner.Arg.(value & opt string cwd & info ["assets"]
+  Cmdliner.Arg.(value & opt (some string) None & info ["assets"]
                   ~docv:"DIR" ~doc)
 
 let csw_cmd =

--- a/src/global.ml
+++ b/src/global.ml
@@ -46,11 +46,11 @@ type cli_options = {
   outfile: string option;
   suffix: string;
   root: string;
-  manual: string;
-  api: string;
+  manual: string option;
+  api: string option;
   default_subproject: string option;
-  images: string;
-  assets: string;
+  images: string option;
+  assets: string option;
   csw: string list;
 }
 let ref_options : cli_options option ref = ref None
@@ -67,15 +67,23 @@ let using_options k = match !ref_options with
   | None -> failwith "Global.options isn't properly intialized."
 
 let options () = using_options Utils.id
-
-let root () = (options ()).root
-let manual () = (options ()).manual
-let api () = (options ()).api
-let images () = (options ()).images
-let assets () = (options ()).assets
 let suffix () = (options ()).suffix
 
+let the_manual () = match (options ()).manual with
+  | Some s -> s
+  | None -> failwith "no manual given"
+let the_api ()    = match (options ()).api with
+  | Some s -> s
+  | None -> failwith "no api given"
+let the_images () = match (options ()).images with
+  | Some s -> s
+  | None -> failwith "no images given"
+let the_assets () = match (options ()).assets with
+  | Some s -> s
+  | None -> failwith "no assets given"
+
 (* Preserve absolute path *)
+let root () = (options ()).root
 let version_dir = root
 let project_dir () = version_dir () |> Filename.dirname
 let all_projects_dir () = project_dir () |> Filename.dirname

--- a/src/global.mli
+++ b/src/global.mli
@@ -28,11 +28,11 @@ type cli_options = {
   outfile: string option;
   suffix: string;
   root: string;
-  manual: string;
-  api: string;
+  manual: string option;
+  api: string option;
   default_subproject: string option;
-  images: string;
-  assets: string;
+  images: string option;
+  assets: string option;
   csw: string list;
 }
 
@@ -44,19 +44,20 @@ val using_options : (cli_options -> 'a) -> 'a
 (** Returns the more recently set [cli_options]. *)
 val options : unit -> cli_options
 
-(** Returns [(options ()).root]. *)
-val root   : unit -> string
-(** Returns [(options ()).manual]. *)
-val manual : unit -> string
-(** Returns [(options ()).api]. *)
-val api    : unit -> string
-(** Returns [(options ()).images]. *)
-val images : unit -> string
-(** Returns [(options ()).assets]. *)
-val assets : unit -> string
 (** Returns [(options ()).suffix]. *)
 val suffix : unit -> string
 
+(** Returns the value of [(options ()).manual] is any, or raises [Failure]. *)
+val the_manual : unit -> string
+(** Returns the value of [(options ()).api] is any, or raises [Failure]. *)
+val the_api    : unit -> string
+(** Returns the value of [(options ()).images] is any, or raises [Failure]. *)
+val the_images : unit -> string
+(** Returns the value of [(options ()).assets] is any, or raises [Failure]. *)
+val the_assets : unit -> string
+
+(** Returns [(options ()).root]. *)
+val root : unit -> string
 (** Alias for [root ()]. *)
 val version_dir : unit -> string
 (** Returns the absolute path to the project directory

--- a/src/links.ml
+++ b/src/links.ml
@@ -9,7 +9,7 @@ let a_link_of_uri ?fragment suffix uri contents =
 let manual_link contents = function
   | [project; chapter; fragment; Some version] ->
     let file = Global.current_file () in
-    let {Global.root; manual} = Global.options () in
+    let root, manual = Global.(root (), the_manual ()) in
     let uri = match (project, chapter) with
       | (Some p, Some c) -> Paths.(rewind root file (* inside this version dir *)
                                    +/+ up (* inside project dir *)
@@ -29,7 +29,7 @@ let manual_link contents = function
 let api_link prefix contents = function
   | [project; subproject; text; Some version] ->
     let file = Global.current_file () in
-    let {Global.root; api} = Global.options () in
+    let root, api = Global.(root (), the_api ()) in
     let id = Api.parse_contents (contents <$> String.trim) in
     let dsp = (Global.options ()).default_subproject in
     let base = match (project, subproject, dsp) with
@@ -47,7 +47,7 @@ let api_link prefix contents = function
 let img_link contents = function
   | [Some src] ->
     let file = Global.current_file () in
-    let {Global.root; images} = Global.options () in
+    let root, images = Global.(root (), the_images ()) in
     let uri = Paths.(rewind root file +/+ images +/+ src) in
     let alt = Filename.basename src in
     Lwt.return [Html.img ~src:uri ~alt ()]
@@ -57,7 +57,7 @@ let img_link contents = function
 let file_link contents = function
   | [Some src] ->
     let file = Global.current_file () in
-    let {Global.root; assets} = Global.options () in
+    let root, assets = Global.(root (), the_assets ()) in
     let uri = Paths.(rewind root file +/+ assets +/+ src) in
     Lwt.return [a_link_of_uri None uri (Some (contents |? Filename.basename uri))]
   | [None] -> failwith "a_file: no src argument error"

--- a/src/ohow.ml
+++ b/src/ohow.ml
@@ -85,11 +85,14 @@ let main {Global.print; headless; outfile; suffix; root; manual; api; default_su
                        lazy (List.for_all Sys.file_exists files))];
   init_extensions ();
   let root = Paths.realpath root in
-  let relative_to_root p = Paths.path_rm_prefix root @@ Paths.realpath p in
-  let manual = relative_to_root manual in
-  let api = relative_to_root api in
-  let images = relative_to_root images in
-  let assets = relative_to_root assets in
+  let relative_to_root p =
+    try Paths.path_rm_prefix root @@ Paths.realpath p
+    with Failure _ -> p
+  in
+  let manual = manual <$> relative_to_root in
+  let api = api <$> relative_to_root in
+  let images = images <$> relative_to_root in
+  let assets = assets <$> relative_to_root in
   let opts = {Global.print; headless; outfile; suffix; root; manual; api; default_subproject; images; assets; csw; files} in
   Global.with_options opts
     (fun () ->

--- a/src/wiki_syntax.ml
+++ b/src/wiki_syntax.ml
@@ -240,10 +240,18 @@ let link_kind bi addr =
     begin match p with
       | "href" ->
         let menu_page = Global.using_menu_file (fun mf ->
+            let open Utils.Operators in
             let {Global.root; manual; api} = Global.options () in
             let file = Global.current_file () in
-            let is_manual = Paths.(is_inside_dir (root +/+ manual) file) in
-            let is_api = Paths.(is_inside_dir (root +/+ api) file) in
+            let is_manual = manual
+                            <$> (fun m -> Paths.(is_inside_dir (root +/+ m) file))
+                            |? false
+            in
+            let is_api = api
+                         <$> (fun a -> Paths.(is_inside_dir (root +/+ a) file))
+                         |? false
+            in
+            let manual, api = manual |? "", api |? "" in
             match mf with
             | Manual _ when is_manual -> page
             | Api _ when is_api -> Paths.(rewind root file +/+ api +/+ page)


### PR DESCRIPTION
- manual, api, images and assets entries' type of cli_options -> string option.
- Add the_X functions.
- Fixes the menu extension NOT to trigger an error (Sys_error raised by the call
  to Utils.find_files) when the manual or api directories are not given.