### PR TITLE
Fix wit: supress backslash interpretation (\\ -> \)

### DIFF
--- a/src/wit.ml
+++ b/src/wit.ml
@@ -4,7 +4,7 @@ let replace_content_tag tmpl content =
   let regexp = Str.regexp "<<content>>" in
   try
     ignore @@ Str.search_forward regexp tmpl 0;
-    Some (Str.replace_first regexp content tmpl)
+    Some (Str.substitute_first regexp (fun _ -> content) tmpl)
   with Not_found ->
     None
 


### PR DESCRIPTION
The function [Str.replace_first regexp content s] interprets \1, \2, etc.
inside [content] as matching result but it also interprets \\ (wikicreole
linebreak) as being an escaped backslash and transforms it into a single
backslash in the returned string.
The function [Str.substitute_first] has the same behaviour as
[Str.replace_first] but it does not interprets backslashes as being an
escaping character, solving the problem.

This is the reason why code snippets inside api wikis had backslashes
instead of HTML <br/> tags where a linebreak were expected.