### PR TITLE
Add extension when-project.

### DIFF
--- a/src/paths.ml
+++ b/src/paths.ml
@@ -51,3 +51,14 @@ let concat_uri_suffix suffix = function
   | "" -> failwith "concat_uri_suffix: empty uri"
   | uri when uri.[String.length uri - 1] = '/' -> uri
   | uri -> uri ^ suffix
+
+let apply_path =
+  let rec loop n path = match Filename.basename path with
+    | "/" -> "/"
+    | "." when path = "" || path = "." -> ""
+    | "" | "." -> loop n (Filename.dirname path)
+    | ".." -> loop (n + 1) (Filename.dirname path)
+    | _ when n > 0 -> loop (n - 1) (Filename.dirname path)
+    | b -> loop n (Filename.dirname path) +/+ b
+  in
+  loop 0

--- a/src/paths.mli
+++ b/src/paths.mli
@@ -40,3 +40,7 @@ val is_visible_dir : string -> bool
 (** [concat_uri_suffix s u] concatenates [u] with [s] if [u] doesn't ends
     with a ['/']. Raises [Failure] when [u] is [""]. *)
 val concat_uri_suffix : string -> string -> string
+
+(** [apply_path p] returns the path [p] without [..]s and [.]s.
+    Example: [apply_path "a//../b/.//./c/.." = "b"] *)
+val apply_path : string -> string

--- a/src/wiki_ext.ml
+++ b/src/wiki_ext.ml
@@ -103,6 +103,22 @@ let do_drawer wp bi args c =
      in
      Lwt.return [ elt ])
 
+let do_when_project _ _ args c =
+  let open Utils.Operators in
+  let project = match Ocsimore_lib.get_opt args "project" with
+    | Some p -> p
+    | None -> failwith "when_project: required argument \"project\" missing"
+  in
+  let root = Global.root () in
+  let current = Paths.(root +/+ up
+                       |> apply_path
+                       |> Filename.basename)
+  in
+  if project = current
+  then `Flow5 (Lwt.return (c <$> Wiki_syntax.compile |? []))
+  else `Flow5 (Lwt.return [])
+
+
 let init () =
   Wiki_syntax.register_raw_wiki_extension ~name:"outline"
     ~wp:Wiki_syntax.wikicreole_parser
@@ -118,4 +134,8 @@ let init () =
   Wiki_syntax.register_raw_wiki_extension ~name:"drawer"
     ~wp:Wiki_syntax.wikicreole_parser
     ~wp_rec:Wiki_syntax.wikicreole_parser
-    do_drawer
+    do_drawer;
+  Wiki_syntax.register_raw_wiki_extension ~name:"when-project"
+    ~wp:Wiki_syntax.wikicreole_parser
+    ~wp_rec:Wiki_syntax.wikicreole_parser
+    do_when_project


### PR DESCRIPTION
`<<when-project project="P" | content>>` inserts the compiled
`content` only if the wiki being compiled is within the given
project (equal directory names).