### PR TITLE
"Fix": syntax error in wikisyntax

### DIFF
--- a/dop.sh
+++ b/dop.sh
@@ -251,6 +251,7 @@ call_ohow() {
     [ -n "$images" ] && opts="$opts --images $images"
     [ -n "$default_subp" ] && opts="$opts --default-subproject $default_subp"
     [ -n "$docversions" ] && opts="$opts --docversions $docversions"
+    [ -n "$templates" ] && opts="$opts --template $templates"
 
     if $csw
     then $ohow $opts --csw <(csw) $1
@@ -278,22 +279,6 @@ normalize_templates() {
                      else echo Could not find template $t. Aborting.; exit $EXIT_CONFIG
                      fi
                  done <<< "$templates"`"
-}
-
-inline_template() {
-    local f=$(mktemp)
-    $wit $1 < $2 > $f && cat $f > $2 || return 1
-    rm $f
-}
-inline_templates() {
-    $verbose && echo -n "Template inlining "
-    normalize_templates
-    while read -r t; do
-        while read -r wiki; do
-            inline_template "$t" $wiki
-        done <<< $(find_wikis)
-    done <<< "$templates"
-    $verbose && echo [OK] || true
 }
 
 compile() {
@@ -386,7 +371,6 @@ $no_run && exit $EXIT_SUCCESS
 ### Compilation
 docversions=$(safe_read_file "$docversions")
 cp -r $wikidir $root
-inline_templates
 compile
 if $menu && ! $keep_wikis; then
    find $root -name menu.wiki -exec rm {} \;

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -48,6 +48,12 @@ let assets_cmd =
   Cmdliner.Arg.(value & opt (some string) None & info ["assets"]
                   ~docv:"DIR" ~doc)
 
+let template_cmd =
+  let doc = "Use the given template." in
+  Cmdliner.Arg.(value & opt (some file) None &
+                info ["t"; "template"]
+                  ~docv:"FILE" ~doc)
+
 let csw_cmd =
   let doc = "Use the given list of wikis which must have a clientserverswitch." in
   Cmdliner.Arg.(value & opt (some file) None &
@@ -125,14 +131,14 @@ manual directory and the api directory."
     Term.info "ohow" ~version:"v0.0.0" ~doc ~exits:Term.default_exits ~man)
 
 
-let register_options k print headless outfile root manual api default_subproject images assets csw docversions local files =
+let register_options k print headless outfile root manual api default_subproject images assets template csw docversions local files =
   let open Utils.Operators in
   let suffix = if local then ".html" else "" in
   let csw = csw <$> Utils.read_file_lines |? [] in
   let docversions = docversions <$> Utils.read_file_lines |? [] in
   let opts = {Global.print; headless; outfile; suffix; root;
               manual; api; default_subproject; images; assets;
-              csw; docversions; local; files} in
+              template; csw; docversions; local; files} in
   Global.with_options opts (fun () -> k opts)
 
 let run main =
@@ -147,6 +153,7 @@ let run main =
       $ default_subproject_cmd
       $ img_cmd
       $ assets_cmd
+      $ template_cmd
       $ csw_cmd
       $ docversions_cmd
       $ local_cmd

--- a/src/global.ml
+++ b/src/global.ml
@@ -52,6 +52,7 @@ type cli_options = {
   default_subproject: string option;
   images: string option;
   assets: string option;
+  template: string option;
   csw: string list;
   docversions: string list;
 }

--- a/src/global.mli
+++ b/src/global.mli
@@ -34,6 +34,7 @@ type cli_options = {
   default_subproject: string option;
   images: string option;
   assets: string option;
+  template: string option;
   csw: string list;
   docversions: string list;
 }

--- a/src/ohow.ml
+++ b/src/ohow.ml
@@ -55,7 +55,10 @@ let infer_output_file file = (infer_wiki_name file) ^ ".html"
 let ohow file oc =
   file
   |> Utils.read_file
-  |> Wiki_syntax.compile
+  |> (fun wiki -> match (Global.options ()).template with
+      | Some template ->
+        Utils.read_file template |> Wiki_syntax.compile_with_content wiki
+      | None -> Wiki_syntax.compile wiki)
   |> (fun c ->
       if (Global.options ()).headless
       then List.iter (pprint oc) c
@@ -82,7 +85,7 @@ let init_extensions () =
 
 let main {Global.print; headless; outfile; suffix; root;
           manual; api; default_subproject; images; assets;
-          csw; docversions; local; files} =
+          template; csw; docversions; local; files} =
   Utils.check_errors [("Some input files doesn't exist...",
                        lazy (List.for_all Sys.file_exists files))];
   init_extensions ();
@@ -97,7 +100,7 @@ let main {Global.print; headless; outfile; suffix; root;
   let assets = assets <$> relative_to_root in
   let opts = {Global.print; headless; outfile; suffix; root;
               manual; api; default_subproject; images; assets;
-              csw; docversions; local; files} in
+              template; csw; docversions; local; files} in
   Global.with_options opts
     (fun () ->
        ((match (outfile, print) with

--- a/src/wiki_syntax.ml
+++ b/src/wiki_syntax.ml
@@ -2193,14 +2193,17 @@ let () =
   register_simple_phrasing_extension ~name:"title" f_title
 
 
-let compile text =
+let compile_with_content content_text text =
   let par = cast_wp wikicreole_parser in
-  let bi = Wiki_widgets_interface.{
-      bi_page = Site "";
-      bi_sectioning = false;
-      bi_add_link = ignore;
-      bi_content = Lwt.return [];
-      bi_title = "";
-    }
+  let bi_with_content c =
+    Wiki_widgets_interface.{bi_page = Site "";
+                            bi_sectioning = false;
+                            bi_add_link = ignore;
+                            bi_content = c;
+                            bi_title = "";}
   in
-  Lwt_main.run @@ xml_of_wiki par bi text
+  let c = xml_of_wiki par (bi_with_content @@ Lwt.return []) content_text in
+  xml_of_wiki par (bi_with_content c) text
+  |> Lwt_main.run
+
+let compile text = compile_with_content "" text

--- a/src/wiki_syntax.mli
+++ b/src/wiki_syntax.mli
@@ -436,3 +436,8 @@ val class_wikibox: wikibox -> string
 
 (** Compiles a wikicreole string and returns its Tyxml structure. *)
 val compile : string -> Html_types.flow5 Tyxml.Html.elt list
+
+(** [compile_with_content content wiki] first compiles [content] and then
+    compiles [wiki] with the result of [content]'s compilation to be
+    used by the [<<content>>] extension. *)
+val compile_with_content : string -> string -> Html_types.flow5 Tyxml.Html.elt list


### PR DESCRIPTION
The wikicréole parser cannot parse the following form, albeit correct:

    <<div|
      <<div id="a>>b"|content>>
    >>

The problem is the value of the `id` attribute: the parser doesen't accept
it since it contains two angle brackets `>>` which it interprets as the
end of the extension.
The error triggered says `syntax error in wikisyntax`.

With ohow however, that situation became much more frequent. Indeed, instead
of being compiled separately and then combined, the template and each wiki
are *first* combined (`s/<<content>>/wiki content/`) and then compiled as being
a single big wiki file.
In Ocsigen's template there are some enclosing `<<div` that surrounds the wiki
content and some wikis include documentation for the bind operator `(>>=)`
which code snippet look like this:

    <<pre id="VAL(>>=)" ...

That obviously triggers the problem described above because of the template's
enclosing `div`s.

This "fix" adds to `ohow` another option, `--template`, in order to restore
the old `<<content>>` insertion with the mixed compilation.
Still it does not fixes the wikicreole.mll parser: anyone can make it fail
by replicating this situation (unintentionally or not) in some wiki's content.