### PR TITLE
Add hack to make ocsigen.github.io compile witout modifications in links.

### DIFF
--- a/src/global.ml
+++ b/src/global.ml
@@ -91,3 +91,6 @@ let root () = (options ()).root
 let version_dir = root
 let project_dir () = version_dir () |> Filename.dirname
 let all_projects_dir () = project_dir () |> Filename.dirname
+
+
+let root_to_site = ref Paths.(up +/+ up)

--- a/src/global.mli
+++ b/src/global.mli
@@ -70,3 +70,8 @@ val project_dir : unit -> string
 (** Returns the absolute path to the directory containing all projects
     ([project_dir]'s parent directory). *)
 val all_projects_dir : unit -> string
+
+
+(** The path to take from the project's root to end up in the website root
+    (i.e., where the links [[site:x]] starts to). Defaults to [[up +/+ up]]. *)
+val root_to_site : string ref

--- a/src/links.ml
+++ b/src/links.ml
@@ -12,10 +12,9 @@ let manual_link contents = function
     let root, manual = Global.(root (), the_manual ()) in
     let uri = match (project, chapter) with
       | (Some p, Some c) -> Paths.(rewind root file (* inside this version dir *)
-                                   +/+ up (* inside project dir *)
-                                   +/+ up (* inside all projects dir *)
+                                   +/+ !Global.root_to_site (* inside project dir *)
                                    +/+ p +/+ version +/+ manual +/+ c)
-      | (Some p, None) -> Paths.(rewind root file +/+ up +/+ up +/+ p +/+ version +/+ "index")
+      | (Some p, None) -> Paths.(rewind root file +/+ !Global.root_to_site +/+ p +/+ version +/+ "index")
       | (None, Some c) -> Paths.(rewind root file +/+ manual +/+ c)
       | (None, None) -> failwith "a_manual: no project nor chapter arg found"
     in
@@ -33,8 +32,8 @@ let api_link prefix contents = function
     let id = Api.parse_contents (contents <$> String.trim) in
     let dsp = (Global.options ()).default_subproject in
     let base = match (project, subproject, dsp) with
-      | (Some p, Some s, _) -> Paths.(rewind root file +/+ up +/+ up +/+ p +/+ version +/+ api +/+ s)
-      | (Some p, None, _) -> Paths.(rewind root file +/+ up +/+ up +/+ p +/+ version +/+ api)
+      | (Some p, Some s, _) -> Paths.(rewind root file +/+ !Global.root_to_site +/+ p +/+ version +/+ api +/+ s)
+      | (Some p, None, _) -> Paths.(rewind root file +/+ !Global.root_to_site +/+ p +/+ version +/+ api)
       | (None, Some s, _) | (None, None, Some s) -> Paths.(rewind root file +/+ api +/+ s)
       | (None, None, None) -> (Paths.rewind root file) +/+ api
     in

--- a/src/ohow.ml
+++ b/src/ohow.ml
@@ -101,6 +101,10 @@ let main {Global.print; headless; outfile; suffix; project; root;
   let opts = {Global.print; headless; outfile; suffix; project; root;
               manual; api; default_subproject; images; assets;
               template; csw; docversions; local; files} in
+  begin match Sys.getenv_opt "HOW_HACK_NOPROJECT" with
+    | Some _ -> Global.root_to_site := ""
+    | None -> ()
+  end;
   Global.with_options opts
     (fun () ->
        ((match (outfile, print) with

--- a/src/wiki_syntax.ml
+++ b/src/wiki_syntax.ml
@@ -226,7 +226,7 @@ let wiki_kind prot page =
       let wiki = extract_wiki_name wiki in
       let file = Global.current_file () in
       let root = Global.root () in
-      Absolute (Paths.(rewind root file +/+ up +/+ up +/+ wiki +/+ page))
+      Absolute (Paths.(rewind root file +/+ !Global.root_to_site +/+ wiki +/+ page))
 
 let this_wiki_kind prot page =
   let file = Global.current_file () in
@@ -262,7 +262,7 @@ let link_kind bi addr =
       | "site" ->
         let file = Global.current_file () in
         let root = Global.root () in
-        Absolute Paths.(rewind root file +/+ up +/+ up +/+ (Utils.trim '/' page))
+        Absolute Paths.(rewind root file +/+ !Global.root_to_site +/+ (Utils.trim '/' page))
       | p when starts_with "wiki(" p -> wiki_kind p page
       | p when starts_with "wiki" p -> this_wiki_kind p page
       | _ -> failwith @@ "unknown prototype: '" ^ p ^ "'"


### PR DESCRIPTION
@balat I'll document that hack in an issue tomorrow. It is not a bad one, pretty easy to get rid of it but it would require to work on all project's CI again...
With it implemented, the work on `ocsigen.github.io` is done.