### PR TITLE
Fix sorting of versions

### DIFF
--- a/quickdop.sh
+++ b/quickdop.sh
@@ -37,7 +37,7 @@ shift 2
 } || true
 
 docversions() {
-    find "$1" -maxdepth 1 -type d -exec basename {} \; | grep -E '[0-9.]+|dev' | sort
+    find "$1" -maxdepth 1 -type d -exec basename {} \; | grep -E '[0-9.]+|dev' | sort -Vr
 }
 
 dv="$(docversions "$project")"


### PR DESCRIPTION
`man sort ` says:
```
-r, --reverse
              reverse the result of comparisons
-V, --version-sort
              natural sort of (version) numbers within text
```