### PR TITLE
Add partial support for odoc links

### DIFF
--- a/src/ohow/api.mli
+++ b/src/ohow/api.mli
@@ -1,0 +1,6 @@
+type id
+
+val parse_contents : string option -> id
+val string_of_id : ?spacer:string -> id -> string
+val fragment_of_id : id -> string option
+val path_of_id : ?prefix:string -> id -> string

--- a/src/ohow/api.mli
+++ b/src/ohow/api.mli
@@ -2,5 +2,13 @@ type id
 
 val parse_contents : string option -> id
 val string_of_id : ?spacer:string -> id -> string
-val fragment_of_id : id -> string option
-val path_of_id : ?prefix:string -> id -> string
+
+module Ocamldoc : sig
+  val fragment_of_id : id -> string option
+  val path_of_id : ?prefix:string -> id -> string
+end
+
+module Odoc : sig
+  val fragment_of_id : id -> string option
+  val path_of_id : id -> string
+end

--- a/src/ohow/extensions.ml
+++ b/src/ohow/extensions.ml
@@ -1,15 +1,14 @@
-open Utils.Operators
-
-let get_opts ?defaults opts args =
+let get_opts ?defaults opts args : string option list =
   let values = List.map (Ocsimore_lib.get_opt args) opts in
-  defaults
-  <$> (fun def ->
-        List.map2
-          (fun sx -> function
-            | Some d -> Some (sx |? d)
-            | None -> sx)
-          values def)
-  |? values
+  match defaults with
+  | None -> values
+  | Some defaults ->
+    let pick_first_some first second =
+      match first with
+      | Some _ -> first
+      | None -> second
+    in
+    List.map2 (fun v def -> pick_first_some v def) values defaults
 
 let _reg name f =
   let wp_rec = Wiki_syntax.phrasing_wikicreole_parser in

--- a/src/ohow/extensions.mli
+++ b/src/ohow/extensions.mli
@@ -1,0 +1,14 @@
+val get_opts :
+     ?defaults:string option list
+  -> string list (* opts *)
+  -> (string * string) list (* args *)
+  -> string option list
+
+val register :
+     ?defaults:string option list
+  -> string (* name *)
+  -> string list (* opts *)
+  -> (   string option
+      -> string option list
+      -> [< Html_types.span_content_fun > `Span ] Tyxml_html.elt list)
+  -> unit

--- a/src/ohow/links.ml
+++ b/src/ohow/links.ml
@@ -34,7 +34,19 @@ let manual_link contents = function
   | _ -> assert false
 
 let api_link prefix contents = function
-  | [ project; subproject; text; Some version ] ->
+  | project :: subproject :: text :: Some version :: (([] | [ _ ]) as kind_opt)
+    ->
+    let kind =
+      match (prefix, kind_opt) with
+      | None, [ Some "odoc" ] -> `Odoc
+      | None, [ Some "ocamldoc" ] -> `Ocamldoc
+      | None, [ Some _ ] -> `Ocamldoc
+      | None, [ None ] -> assert false
+      | None, [] -> assert false
+      | Some _, [] -> `Ocamldoc
+      | Some _, [ _ ] -> assert false
+      | _, _ :: _ :: _ -> assert false
+    in
     let file = Global.current_file () in
     let root, api = Global.(root (), the_api ()) in
     let id = Api.parse_contents (contents <$> String.trim) in
@@ -52,8 +64,19 @@ let api_link prefix contents = function
         Paths.(rewind root file +/+ api +/+ s)
       | None, None, None -> Paths.rewind root file +/+ api
     in
-    let uri = Filename.concat base @@ Api.Ocamldoc.path_of_id ?prefix id in
-    let fragment = Api.Ocamldoc.fragment_of_id id in
+    let path_of_id =
+      match (kind, prefix) with
+      | `Ocamldoc, ((None | Some _) as prefix) ->
+        Api.Ocamldoc.path_of_id ?prefix id
+      | `Odoc, None -> Api.Odoc.path_of_id id
+      | `Odoc, Some _ -> assert false
+    in
+    let uri = Filename.concat base @@ path_of_id in
+    let fragment =
+      match kind with
+      | `Ocamldoc -> Api.Ocamldoc.fragment_of_id id
+      | `Odoc -> Api.Odoc.fragment_of_id id
+    in
     let body = text |? Api.string_of_id ~spacer:"." id in
     [ a_link_of_uri ?fragment (Some (Global.suffix ())) uri (Some body) ]
   | _ -> assert false
@@ -83,13 +106,15 @@ let init () =
       [ "project"; "chapter"; "fragment"; "version" ]
       ~defaults:[ None; None; None; Some "latest" ]
       manual_link;
-    [ None; Some "type"; Some "code" ]
+    register "a_api"
+      [ "project"; "subproject"; "text"; "version"; "kind" ]
+      ~defaults:[ None; None; None; Some "latest"; Some "ocamldoc" ]
+      (api_link None);
+    [ "type"; "code" ]
     |> List.iter (fun p ->
-           let name = "a_api" ^ (p <$> (fun p -> "_" ^ p) |? "") in
-           let prefix = p <$> fun p -> p ^ "_" in
-           register name
+           register ("a_api_" ^ p)
              [ "project"; "subproject"; "text"; "version" ]
              ~defaults:[ None; None; None; Some "latest" ]
-             (api_link prefix));
+             (api_link (Some (p ^ "_"))));
     register "a_img" [ "src" ] img_link;
     register "a_file" [ "src" ] file_link)

--- a/src/ohow/links.ml
+++ b/src/ohow/links.ml
@@ -43,7 +43,22 @@ let api_link prefix contents = function
       | None, [ Some _ ] -> `Ocamldoc
       | None, [ None ] -> assert false
       | None, [] -> assert false
-      | Some _, [] -> `Ocamldoc
+      | Some _, [] -> (
+        let target_project =
+          match project with
+          | None -> Filename.basename (Global.project_dir ())
+          | Some p -> p
+        in
+        match target_project with
+        | "js_of_ocaml" -> (
+          match version with
+          | "latest" | "dev" -> `Odoc
+          | v ->
+            let v = Version.parse v in
+            if Version.compare v (Version.parse "3.5.0") < 0
+            then `Ocamldoc
+            else `Odoc)
+        | _ -> `Ocamldoc)
       | Some _, [ _ ] -> assert false
       | _, _ :: _ :: _ -> assert false
     in

--- a/src/ohow/links.ml
+++ b/src/ohow/links.ml
@@ -67,17 +67,21 @@ let api_link prefix contents = function
     let id = Api.parse_contents (contents <$> String.trim) in
     let dsp = (Global.options ()).default_subproject in
     let base =
-      match (project, subproject, dsp) with
-      | Some p, Some s, _ ->
+      match (project, subproject, dsp, kind) with
+      | Some p, Some s, _, _ ->
         Paths.(
           rewind root file +/+ !Global.root_to_site +/+ p +/+ version +/+ api
           +/+ s)
-      | Some p, None, _ ->
+      | Some p, None, _, `Ocamldoc ->
         Paths.(
           rewind root file +/+ !Global.root_to_site +/+ p +/+ version +/+ api)
-      | None, Some s, _ | None, None, Some s ->
+      | Some p, None, _, `Odoc ->
+        Paths.(
+          rewind root file +/+ !Global.root_to_site +/+ p +/+ version +/+ api
+          +/+ p)
+      | None, Some s, _, _ | None, None, Some s, _ ->
         Paths.(rewind root file +/+ api +/+ s)
-      | None, None, None -> Paths.rewind root file +/+ api
+      | None, None, None, _ -> Paths.rewind root file +/+ api
     in
     let path_of_id =
       match (kind, prefix) with

--- a/src/ohow/links.ml
+++ b/src/ohow/links.ml
@@ -52,8 +52,8 @@ let api_link prefix contents = function
         Paths.(rewind root file +/+ api +/+ s)
       | None, None, None -> Paths.rewind root file +/+ api
     in
-    let uri = Filename.concat base @@ Api.path_of_id ?prefix id in
-    let fragment = Api.fragment_of_id id in
+    let uri = Filename.concat base @@ Api.Ocamldoc.path_of_id ?prefix id in
+    let fragment = Api.Ocamldoc.fragment_of_id id in
     let body = text |? Api.string_of_id ~spacer:"." id in
     [ a_link_of_uri ?fragment (Some (Global.suffix ())) uri (Some body) ]
   | _ -> assert false

--- a/src/ohow/links.ml
+++ b/src/ohow/links.ml
@@ -127,7 +127,7 @@ let init () =
       manual_link;
     register "a_api"
       [ "project"; "subproject"; "text"; "version"; "kind" ]
-      ~defaults:[ None; None; None; Some "latest"; Some "ocamldoc" ]
+      ~defaults:[ None; None; None; Some "latest"; None ]
       (api_link None);
     [ "type"; "code" ]
     |> List.iter (fun p ->

--- a/src/ohow/utils.ml
+++ b/src/ohow/utils.ml
@@ -1,19 +1,24 @@
-module Operators = struct
-  let ( >>= ) x f =
+module Option = struct
+  let bind x f =
     match x with
     | Some x -> f x
     | None -> None
 
-  let ( <$> ) x f =
+  let map x f =
     match x with
     | Some x -> Some (f x)
     | None -> None
 
-  let ( |? ) x default =
+  let value x ~default =
     match x with
     | Some x -> x
     | None -> default
+end
 
+module Operators = struct
+  let ( >>= ) = Option.bind
+  let ( <$> ) = Option.map
+  let ( |? ) x default = Option.value x ~default
   let ( +/+ ) p q = Paths.(p +/+ q)
 end
 

--- a/src/ohow/utils.mli
+++ b/src/ohow/utils.mli
@@ -1,3 +1,13 @@
+module Option : sig
+  (** Bind operator for the Maybe monad *)
+  val bind : 'a option -> ('a -> 'b option) -> 'b option
+
+  (** Map operator for the Maybe monad *)
+  val map : 'a option -> ('a -> 'b) -> 'b option
+
+  val value : 'a option -> default:'a -> 'a
+end
+
 (** Defines general purpose operators. *)
 module Operators : sig
   (** Bind operator for the Maybe monad *)


### PR DESCRIPTION
- Implement the odoc link schema
- add new optional parameter for the `a_api` extention (`kind="ocamldoc"` | `kind="odoc"`)
- use  the odoc schema for js_of_ocaml starting with version 3.5.0 (hardcoded)

This branch is used to generated js_of_ocaml dev documentation