### PR TITLE
[ci] Remove the incompatible versions of the OCaml compiler

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,9 +17,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4.05.x
-          - 4.06.x
-          - 4.07.x
           - 4.08.x
           - 4.09.x
           - 4.10.x

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ markup language (almost :wink:) expressivity as HTML!
 
 ## Installation
 
-Requires OCaml 4.05 or greater (use `opam switch`) and the `opam` package
+Requires OCaml 4.08 or greater (use `opam switch`) and the `opam` package
 manager.
 
 ```bash


### PR DESCRIPTION
`html_of_wiki` requires OCaml 4.08 or greater because Cmdliner 1.1 or greater does too.  See
https://github.com/ocsigen/html_of_wiki/actions/runs/4722958786.