### PR TITLE
Add ocaml to depends

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -31,6 +31,7 @@
  (description
   "a static website generator for software projects, using wikicreole syntax.")
  (depends
+  (ocaml (< 5.0))
   ("cmdliner" (>= 1.1.1))
   "js_of_ocaml-ppx_deriving_json"
   "js_of_ocaml-ppx"

--- a/html_of_wiki.opam
+++ b/html_of_wiki.opam
@@ -13,6 +13,7 @@ doc: "https://ocsigen.org/html_of_wiki/2.0/manual/intro"
 bug-reports: "https://github.com/ocsigen/html_of_wiki/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml" {< "5.0"}
   "cmdliner" {>= "1.1.1"}
   "js_of_ocaml-ppx_deriving_json"
   "js_of_ocaml-ppx"


### PR DESCRIPTION
Add support for OCaml 5 seems like a non-trivial task as it should be done in a separate PR.