### PR TITLE
Update `Reason_toolchain` namespace for Reason 3.17+

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.18)
+(lang dune 3.19)
 
 (using menhir 3.0)
 (implicit_transitive_deps false)
@@ -26,5 +26,5 @@
   "ocamlfind"
   "re"
   "base64"
-  "reason"
-  ("tyxml"(>= 4.6.0))))
+  ("reason" (>= 3.17))
+  ("tyxml" (>= 4.6))))

--- a/html_of_wiki.opam
+++ b/html_of_wiki.opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocsigen/html_of_wiki"
 doc: "https://ocsigen.org/html_of_wiki/2.0/manual/intro"
 bug-reports: "https://github.com/ocsigen/html_of_wiki/issues"
 depends: [
-  "dune" {>= "3.18"}
+  "dune" {>= "3.19"}
   "ocaml" {< "5.1"}
   "cmdliner" {>= "1.1.1"}
   "js_of_ocaml-ppx_deriving_json"
@@ -21,8 +21,8 @@ depends: [
   "ocamlfind"
   "re"
   "base64"
-  "reason"
-  "tyxml" {>= "4.6.0"}
+  "reason" {>= "3.17"}
+  "tyxml" {>= "4.6"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/client/client.ml
+++ b/src/client/client.ml
@@ -79,12 +79,14 @@ let insert_after ~existing nw =
 let to_reason s =
   let clean = Regexp.(global_replace (regexp "\xa0") s " ") in
   (try
-     Lexing.from_string clean |> Reason_toolchain.ML.interface_with_comments
-     |> Reason_toolchain.RE.print_interface_with_comments Format.str_formatter
+     Lexing.from_string clean
+     |> Reason.Reason_toolchain.ML.interface_with_comments
+     |> Reason.Reason_toolchain.RE.print_interface_with_comments
+          Format.str_formatter
    with _ ->
      Lexing.from_string clean
-     |> Reason_toolchain.ML.implementation_with_comments
-     |> Reason_toolchain.RE.print_implementation_with_comments
+     |> Reason.Reason_toolchain.ML.implementation_with_comments
+     |> Reason.Reason_toolchain.RE.print_implementation_with_comments
           Format.str_formatter);
   Format.flush_str_formatter ()
 


### PR DESCRIPTION
Reason 3.17 exposes `Reason_toolchain` under the Reason module. Update `src/client/client.ml` to use `Reason.Reason_toolchain` for both interface and implementation printers to avoid unbound module errors.