### PR TITLE
Standardise licence identifier to SPDX format and silence opam lint warning

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -5,7 +5,7 @@
 
 (maintainers "The ocsigen team <dev@ocsigen.org>" "Leo Valais <leo.valais97@gmail.com>")
 (authors "The ocsigen team <dev@ocsigen.org>")
-(license "LGPL-2.1 with OCaml linking exception")
+(license "LGPL-2.1-only WITH OCaml-LGPL-linking-exception")
 (source (github ocsigen/html_of_wiki))
 (documentation "https://ocsigen.org/html_of_wiki/2.0/manual/intro")
 

--- a/html_of_wiki.opam
+++ b/html_of_wiki.opam
@@ -8,7 +8,7 @@ maintainer: [
   "The ocsigen team <dev@ocsigen.org>" "Leo Valais <leo.valais97@gmail.com>"
 ]
 authors: ["The ocsigen team <dev@ocsigen.org>"]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocsigen/html_of_wiki"
 doc: "https://ocsigen.org/html_of_wiki/2.0/manual/intro"
 bug-reports: "https://github.com/ocsigen/html_of_wiki/issues"


### PR DESCRIPTION
Update the licence string to the SPDX-compliant identifier "LGPL-2.1-only WITH OCaml-LGPL-linking-exception" to match opam’s expected format and avoid lint warnings.